### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/192/331/421192331.geojson
+++ b/data/421/192/331/421192331.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"NC",
     "wof:created":1459009733,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14bb9b625ca2bf66ab059555d028ede5",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421192331,
-    "wof:lastmodified":1566647726,
+    "wof:lastmodified":1582352229,
     "wof:name":"La Roche",
     "wof:parent_id":85675251,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.