### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/545/869/102545869.geojson
+++ b/data/102/545/869/102545869.geojson
@@ -16,6 +16,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0637\u0627\u0631 \u0644\u0627 \u062a\u0648\u0646\u062a\u0648\u062a\u0627 \u0627\u0644\u062f\u0648\u0644\u064a"
     ],
+    "name:cym_x_preferred":[
+        "Maes Awyr Rhyngwladol La Tontouta"
+    ],
     "name:deu_x_preferred":[
         "Flughafen La Tontouta"
     ],
@@ -38,6 +41,9 @@
     "name:ind_x_preferred":[
         "Bandar Udara Internasional La Tontouta"
     ],
+    "name:ita_x_preferred":[
+        "Numea-La Tontouta"
+    ],
     "name:jpn_x_preferred":[
         "\u30cc\u30e1\u30a2\u56fd\u969b\u7a7a\u6e2f"
     ],
@@ -50,6 +56,9 @@
     "name:msa_x_preferred":[
         "Lapangan Terbang Tontouta"
     ],
+    "name:nob_x_preferred":[
+        "Noum\u00e9a - La Tontouta"
+    ],
     "name:pol_x_preferred":[
         "Port lotniczy Numea-La Tontouta"
     ],
@@ -61,6 +70,9 @@
     ],
     "name:spa_x_preferred":[
         "Aeropuerto Internacional La Tontouta"
+    ],
+    "name:spa_x_variant":[
+        "Noum\u00e9a - La Tontouta"
     ],
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0431\u0438\u043d\u200c\u0430\u043b\u043c\u0438\u043b\u0430\u043b\u04e3 \u043b\u043e \u0442\u043d\u0442\u0443\u0442\u043e"
@@ -100,7 +112,7 @@
         }
     ],
     "wof:id":102545869,
-    "wof:lastmodified":1631751567,
+    "wof:lastmodified":1690848296,
     "wof:name":"La Tontouta Airport",
     "wof:parent_id":85675259,
     "wof:placetype":"campus",

--- a/data/112/598/769/3/1125987693.geojson
+++ b/data/112/598/769/3/1125987693.geojson
@@ -61,6 +61,9 @@
     "name:deu_x_preferred":[
         "Houa\u00eflou"
     ],
+    "name:ell_x_preferred":[
+        "\u039f\u03c5\u03b1\u03ca\u03bb\u03bf\u03cd"
+    ],
     "name:eng_x_preferred":[
         "Houa\u00eflou"
     ],
@@ -308,7 +311,7 @@
         }
     ],
     "wof:id":1125987693,
-    "wof:lastmodified":1566647731,
+    "wof:lastmodified":1690848302,
     "wof:name":"Houa\u00eflou",
     "wof:parent_id":85675261,
     "wof:placetype":"locality",

--- a/data/112/598/770/3/1125987703.geojson
+++ b/data/112/598/770/3/1125987703.geojson
@@ -61,6 +61,9 @@
     "name:deu_x_preferred":[
         "Hiengh\u00e8ne"
     ],
+    "name:ell_x_preferred":[
+        "\u0399\u03b5\u03bd\u03b3\u03ba\u03ad\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Hiengh\u00e8ne"
     ],
@@ -108,6 +111,9 @@
     ],
     "name:hun_x_preferred":[
         "Hiengh\u00e8ne"
+    ],
+    "name:hye_x_preferred":[
+        "\u0540\u056b\u0576\u056b\u0576"
     ],
     "name:ido_x_preferred":[
         "Hiengh\u00e8ne"
@@ -308,7 +314,7 @@
         }
     ],
     "wof:id":1125987703,
-    "wof:lastmodified":1566647731,
+    "wof:lastmodified":1690848302,
     "wof:name":"Hiengh\u00e8ne",
     "wof:parent_id":85675261,
     "wof:placetype":"locality",

--- a/data/112/598/771/5/1125987715.geojson
+++ b/data/112/598/771/5/1125987715.geojson
@@ -262,6 +262,9 @@
     "name:wol_x_preferred":[
         "Dumb\u00e9a"
     ],
+    "name:zho_x_preferred":[
+        "\u4e39\u8d1d\u963f"
+    ],
     "name:zul_x_preferred":[
         "Dumb\u00e9a"
     ],
@@ -305,7 +308,7 @@
         }
     ],
     "wof:id":1125987715,
-    "wof:lastmodified":1566647731,
+    "wof:lastmodified":1690848302,
     "wof:name":"Dumb\u00e9a",
     "wof:parent_id":85675259,
     "wof:placetype":"locality",

--- a/data/112/598/772/1/1125987721.geojson
+++ b/data/112/598/772/1/1125987721.geojson
@@ -61,6 +61,9 @@
     "name:deu_x_preferred":[
         "Canala"
     ],
+    "name:ell_x_preferred":[
+        "\u039a\u03b1\u03bd\u03b1\u03bb\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Canala"
     ],
@@ -308,7 +311,7 @@
         }
     ],
     "wof:id":1125987721,
-    "wof:lastmodified":1566647731,
+    "wof:lastmodified":1690848303,
     "wof:name":"Canala",
     "wof:parent_id":85675261,
     "wof:placetype":"locality",

--- a/data/112/601/174/3/1126011743.geojson
+++ b/data/112/601/174/3/1126011743.geojson
@@ -70,6 +70,9 @@
     "name:ell_x_preferred":[
         "\u039a\u03bf\u03cd\u03bc\u03b1\u03ba"
     ],
+    "name:ell_x_variant":[
+        "\u039a\u03bf\u03c5\u03bc\u03ac\u03ba"
+    ],
     "name:eng_x_preferred":[
         "Koumac"
     ],
@@ -274,6 +277,9 @@
     "name:tha_x_preferred":[
         "\u0e04\u0e39\u0e27\u0e41\u0e21\u0e04"
     ],
+    "name:tha_x_variant":[
+        "\u0e01\u0e39\u0e21\u0e31\u0e01"
+    ],
     "name:tur_x_preferred":[
         "Koumac"
     ],
@@ -306,6 +312,9 @@
     ],
     "name:wol_x_preferred":[
         "Koumac"
+    ],
+    "name:zho_x_preferred":[
+        "\u5e93\u9a6c\u514b"
     ],
     "name:zul_x_preferred":[
         "Koumac"
@@ -350,7 +359,7 @@
         }
     ],
     "wof:id":1126011743,
-    "wof:lastmodified":1566647731,
+    "wof:lastmodified":1690848303,
     "wof:name":"Koumac",
     "wof:parent_id":85675261,
     "wof:placetype":"locality",

--- a/data/112/601/175/1/1126011751.geojson
+++ b/data/112/601/175/1/1126011751.geojson
@@ -58,6 +58,9 @@
     "name:deu_x_preferred":[
         "Kon\u00e9"
     ],
+    "name:ell_x_preferred":[
+        "\u039a\u03bf\u03bd\u03ad"
+    ],
     "name:eng_x_preferred":[
         "Kon\u00e9"
     ],
@@ -305,7 +308,7 @@
         }
     ],
     "wof:id":1126011751,
-    "wof:lastmodified":1566647732,
+    "wof:lastmodified":1690848303,
     "wof:name":"Kon\u00e9",
     "wof:parent_id":85675261,
     "wof:placetype":"locality",

--- a/data/421/178/327/421178327.geojson
+++ b/data/421/178/327/421178327.geojson
@@ -62,6 +62,9 @@
     "name:ell_x_preferred":[
         "\u039f\u03c5\u03b2\u03ad\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u039f\u03c5\u03b2\u03b5\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Ouv\u00e9a"
     ],
@@ -324,7 +327,7 @@
         }
     ],
     "wof:id":421178327,
-    "wof:lastmodified":1566647727,
+    "wof:lastmodified":1690848297,
     "wof:name":"Fayaou\u00e9",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/182/667/421182667.geojson
+++ b/data/421/182/667/421182667.geojson
@@ -56,6 +56,9 @@
     "name:deu_x_preferred":[
         "Poum"
     ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03bf\u03c5\u03bc"
+    ],
     "name:eng_x_preferred":[
         "Poum"
     ],
@@ -309,7 +312,7 @@
         }
     ],
     "wof:id":421182667,
-    "wof:lastmodified":1566647727,
+    "wof:lastmodified":1690848298,
     "wof:name":"Poum",
     "wof:parent_id":85675261,
     "wof:placetype":"locality",

--- a/data/421/200/219/421200219.geojson
+++ b/data/421/200/219/421200219.geojson
@@ -56,6 +56,9 @@
     "name:deu_x_preferred":[
         "Ou\u00e9goa"
     ],
+    "name:ell_x_preferred":[
+        "\u039f\u03c5\u03b5\u03b3\u03ba\u03bf\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Ou\u00e9goa"
     ],
@@ -308,7 +311,7 @@
         }
     ],
     "wof:id":421200219,
-    "wof:lastmodified":1566647726,
+    "wof:lastmodified":1690848297,
     "wof:name":"Ou\u00e9goa",
     "wof:parent_id":85675261,
     "wof:placetype":"locality",

--- a/data/421/201/933/421201933.geojson
+++ b/data/421/201/933/421201933.geojson
@@ -56,6 +56,9 @@
     "name:deu_x_preferred":[
         "Thio"
     ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03b9\u03cc"
+    ],
     "name:eng_x_preferred":[
         "Thio"
     ],
@@ -305,7 +308,7 @@
         }
     ],
     "wof:id":421201933,
-    "wof:lastmodified":1566647727,
+    "wof:lastmodified":1690848297,
     "wof:name":"Thio",
     "wof:parent_id":85675259,
     "wof:placetype":"locality",

--- a/data/890/413/117/890413117.geojson
+++ b/data/890/413/117/890413117.geojson
@@ -43,6 +43,9 @@
     "name:ben_x_preferred":[
         "\u09a8\u0993\u09ae\u09bf\u09af\u09bc\u09be"
     ],
+    "name:ben_x_variant":[
+        "\u09a8\u09c1\u09ae\u09c7\u09af\u09bc\u09be"
+    ],
     "name:bos_x_preferred":[
         "Noum\u00e9a"
     ],
@@ -60,6 +63,9 @@
     ],
     "name:ces_x_preferred":[
         "Noum\u00e9a"
+    ],
+    "name:chv_x_preferred":[
+        "\u041d\u0443\u043c\u0435\u0430"
     ],
     "name:cym_x_preferred":[
         "Noum\u00e9a"
@@ -116,6 +122,12 @@
     "name:fry_x_preferred":[
         "Noum\u00e9a"
     ],
+    "name:gla_x_preferred":[
+        "Numea"
+    ],
+    "name:gle_x_preferred":[
+        "Noumea"
+    ],
     "name:glg_x_preferred":[
         "Noumea"
     ],
@@ -156,7 +168,8 @@
         "Noumea"
     ],
     "name:ita_x_variant":[
-        "Noum\u00e9a"
+        "Noum\u00e9a",
+        "Numea"
     ],
     "name:jpn_x_preferred":[
         "\u30cc\u30e1\u30a2"
@@ -197,8 +210,14 @@
     "name:mkd_x_variant":[
         "\u041d\u0443\u043c\u0435\u0458\u0430"
     ],
+    "name:mlt_x_preferred":[
+        "Noum\u00e9a"
+    ],
     "name:mon_x_preferred":[
         "\u041d\u0443\u043c\u0435\u0430"
+    ],
+    "name:mri_x_preferred":[
+        "N\u016bmea"
     ],
     "name:msa_x_preferred":[
         "Noum\u00e9a"
@@ -230,6 +249,9 @@
     "name:por_x_preferred":[
         "Noum\u00e9a"
     ],
+    "name:pus_x_preferred":[
+        "\u0646\u0648\u0645\u06cc\u0627"
+    ],
     "name:ron_x_preferred":[
         "Noum\u00e9a"
     ],
@@ -257,6 +279,9 @@
     "name:sqi_x_preferred":[
         "Numea"
     ],
+    "name:srd_x_preferred":[
+        "Noum\u00e9a"
+    ],
     "name:srp_x_preferred":[
         "\u041d\u0443\u043c\u0435\u0430"
     ],
@@ -277,6 +302,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c28\u0c4a\u0c2e\u0c47\u0c2f\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u041d\u0443\u043c\u0435\u0430"
     ],
     "name:tgl_x_preferred":[
         "Noum\u00e9a"
@@ -307,6 +335,9 @@
     ],
     "name:war_x_preferred":[
         "Noum\u00e9a"
+    ],
+    "name:wuu_x_preferred":[
+        "\u52aa\u7f8e\u963f"
     ],
     "name:yue_x_preferred":[
         "\u52aa\u7f8e\u963f"
@@ -439,7 +470,7 @@
         }
     ],
     "wof:id":890413117,
-    "wof:lastmodified":1566647728,
+    "wof:lastmodified":1690848298,
     "wof:name":"Noum\u00e9a",
     "wof:parent_id":85675259,
     "wof:placetype":"locality",

--- a/data/890/413/121/890413121.geojson
+++ b/data/890/413/121/890413121.geojson
@@ -58,6 +58,9 @@
     "name:deu_x_preferred":[
         "Sarram\u00e9a"
     ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b1\u03c1\u03b1\u03bc\u03b5\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Sarram\u00e9a"
     ],
@@ -299,7 +302,7 @@
         }
     ],
     "wof:id":890413121,
-    "wof:lastmodified":1566647728,
+    "wof:lastmodified":1690848298,
     "wof:name":"Sarram\u00e9a",
     "wof:parent_id":85675259,
     "wof:placetype":"locality",

--- a/data/890/413/125/890413125.geojson
+++ b/data/890/413/125/890413125.geojson
@@ -67,6 +67,9 @@
     "name:ell_x_preferred":[
         "\u039b\u03b1 \u03a6\u03cc\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u039b\u03b1 \u03a6\u03bf\u03ac"
+    ],
     "name:eng_x_preferred":[
         "La Foa"
     ],
@@ -114,6 +117,9 @@
     ],
     "name:hin_x_preferred":[
         "\u0932\u093e \u092b\u094b\u092f\u093e"
+    ],
+    "name:hin_x_variant":[
+        "\u0932\u093e  \u092b\u094b\u092f\u093e"
     ],
     "name:hrv_x_preferred":[
         "La Foa"
@@ -265,11 +271,17 @@
     "name:tam_x_preferred":[
         "\u0bb2\u0bbe Foa"
     ],
+    "name:tam_x_variant":[
+        "\u0bb2\u0bbe  Foa"
+    ],
     "name:tel_x_preferred":[
         "\u0c32\u0c3e \u0c2b\u0c4b\u0c2f\u0c3e"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e25\u0e2d \u0e1f\u0e39\u0e27\u0e22\u0e4c"
+    ],
+    "name:tha_x_variant":[
+        "\u0e25\u0e32\u0e42\u0e1f\u0e2d\u0e32"
     ],
     "name:tur_x_preferred":[
         "La Foa"
@@ -338,7 +350,7 @@
         }
     ],
     "wof:id":890413125,
-    "wof:lastmodified":1566647728,
+    "wof:lastmodified":1690848299,
     "wof:name":"La Foa",
     "wof:parent_id":85675259,
     "wof:placetype":"locality",

--- a/data/890/428/961/890428961.geojson
+++ b/data/890/428/961/890428961.geojson
@@ -24,6 +24,9 @@
     "name:arg_x_preferred":[
         "B\u00e9lep"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u064a\u0644\u064a\u0633 \u0628\u064a\u0644\u064a\u067e"
+    ],
     "name:ast_x_preferred":[
         "B\u00e9lep"
     ],
@@ -59,6 +62,9 @@
     ],
     "name:deu_x_preferred":[
         "Belep-Inseln"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b5\u03bb\u03ad\u03c0"
     ],
     "name:eng_x_preferred":[
         "\u00celes Belep"
@@ -104,6 +110,9 @@
     ],
     "name:gsw_x_preferred":[
         "B\u00e9lep"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d9\u05d9 \u05d1\u05dc\u05d4"
     ],
     "name:hrv_x_preferred":[
         "B\u00e9lep"
@@ -246,8 +255,14 @@
     "name:swe_x_preferred":[
         "Belep\u00f6arna"
     ],
+    "name:swe_x_variant":[
+        "B\u00e9lep"
+    ],
     "name:tur_x_preferred":[
         "B\u00e9lep"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0411\u0435\u043b\u0435\u043f"
     ],
     "name:vec_x_preferred":[
         "B\u00e9lep"
@@ -269,6 +284,9 @@
     ],
     "name:wol_x_preferred":[
         "B\u00e9lep"
+    ],
+    "name:zho_x_preferred":[
+        "\u8d1d\u83b1\u666e"
     ],
     "name:zul_x_preferred":[
         "B\u00e9lep"
@@ -306,7 +324,7 @@
         }
     ],
     "wof:id":890428961,
-    "wof:lastmodified":1566647730,
+    "wof:lastmodified":1690848301,
     "wof:name":"B\u00e9lep",
     "wof:parent_id":85675261,
     "wof:placetype":"county",

--- a/data/890/430/299/890430299.geojson
+++ b/data/890/430/299/890430299.geojson
@@ -58,6 +58,9 @@
     "name:deu_x_preferred":[
         "Pou\u00e9bo"
     ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03bf\u03c5\u03b5\u03bc\u03c0\u03cc"
+    ],
     "name:eng_x_preferred":[
         "Pou\u00e9bo"
     ],
@@ -298,7 +301,7 @@
         }
     ],
     "wof:id":890430299,
-    "wof:lastmodified":1566647729,
+    "wof:lastmodified":1690848300,
     "wof:name":"Pou\u00e9bo",
     "wof:parent_id":85675261,
     "wof:placetype":"locality",

--- a/data/890/430/307/890430307.geojson
+++ b/data/890/430/307/890430307.geojson
@@ -58,6 +58,9 @@
     "name:deu_x_preferred":[
         "Pa\u00efta"
     ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03b1\u03ca\u03c4\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Pa\u00efta"
     ],
@@ -265,6 +268,9 @@
     "name:zho_x_preferred":[
         "\u76ae\u4e9e\u5854"
     ],
+    "name:zho_x_variant":[
+        "\u5e15\u4f0a\u5854"
+    ],
     "name:zul_x_preferred":[
         "Pa\u00efta"
     ],
@@ -302,7 +308,7 @@
         }
     ],
     "wof:id":890430307,
-    "wof:lastmodified":1566647728,
+    "wof:lastmodified":1690848299,
     "wof:name":"Pa\u00efta",
     "wof:parent_id":85675259,
     "wof:placetype":"locality",

--- a/data/890/432/119/890432119.geojson
+++ b/data/890/432/119/890432119.geojson
@@ -58,6 +58,9 @@
     "name:deu_x_preferred":[
         "Touho"
     ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03bf\u03c5\u03cc"
+    ],
     "name:eng_x_preferred":[
         "Touho"
     ],
@@ -299,7 +302,7 @@
         }
     ],
     "wof:id":890432119,
-    "wof:lastmodified":1566647730,
+    "wof:lastmodified":1690848301,
     "wof:name":"Touho",
     "wof:parent_id":85675261,
     "wof:placetype":"locality",

--- a/data/890/438/255/890438255.geojson
+++ b/data/890/438/255/890438255.geojson
@@ -238,6 +238,9 @@
     "name:tur_x_preferred":[
         "Bourail"
     ],
+    "name:ukr_x_preferred":[
+        "\u0411\u0443\u0440\u0430\u0439"
+    ],
     "name:und_x_variant":[
         "Boureil"
     ],
@@ -298,7 +301,7 @@
         }
     ],
     "wof:id":890438255,
-    "wof:lastmodified":1566647729,
+    "wof:lastmodified":1690848300,
     "wof:name":"Bourail",
     "wof:parent_id":85675259,
     "wof:placetype":"locality",

--- a/data/890/445/349/890445349.geojson
+++ b/data/890/445/349/890445349.geojson
@@ -58,6 +58,9 @@
     "name:deu_x_preferred":[
         "Farino"
     ],
+    "name:ell_x_preferred":[
+        "\u03a6\u03b1\u03c1\u03b9\u03bd\u03cc"
+    ],
     "name:eng_x_preferred":[
         "Farino"
     ],
@@ -293,7 +296,7 @@
         }
     ],
     "wof:id":890445349,
-    "wof:lastmodified":1566647730,
+    "wof:lastmodified":1690848301,
     "wof:name":"Farino",
     "wof:parent_id":85675259,
     "wof:placetype":"locality",

--- a/data/890/452/727/890452727.geojson
+++ b/data/890/452/727/890452727.geojson
@@ -238,6 +238,9 @@
     "name:swe_x_preferred":[
         "Bouloupari"
     ],
+    "name:swe_x_variant":[
+        "Boulouparis"
+    ],
     "name:tur_x_preferred":[
         "Bouloupari"
     ],
@@ -264,6 +267,9 @@
     ],
     "name:wol_x_preferred":[
         "Bouloupari"
+    ],
+    "name:zho_x_preferred":[
+        "\u5e03\u5362\u5e15\u91cc"
     ],
     "name:zul_x_preferred":[
         "Bouloupari"
@@ -302,7 +308,7 @@
         }
     ],
     "wof:id":890452727,
-    "wof:lastmodified":1566647729,
+    "wof:lastmodified":1690848300,
     "wof:name":"Bouloupari",
     "wof:parent_id":85675259,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.