### PR TITLE
nc concordances, placetype local, and more

### DIFF
--- a/data/856/752/51/85675251.geojson
+++ b/data/856/752/51/85675251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175275,
-    "geom:area_square_m":2021939408.931187,
+    "geom:area_square_m":2021939408.930948,
     "geom:bbox":"166.390879754,-21.6584611957,168.144216343,-20.3834774715",
     "geom:latitude":-21.101666,
     "geom:longitude":167.437468,
@@ -136,8 +136,9 @@
         "hasc:id":"NC.IL",
         "qs_pg:id":212377
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NC",
-    "wof:geomhash":"ab05b5e3bcc3f630f362fb3257f11acc",
+    "wof:geomhash":"86fb22c3ed3fa31e44417420f818a592",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -154,7 +155,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566647685,
+    "wof:lastmodified":1695884327,
     "wof:name":"\u00celes Loyaut\u00e9",
     "wof:parent_id":85632473,
     "wof:placetype":"region",

--- a/data/856/752/59/85675259.geojson
+++ b/data/856/752/59/85675259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.639028,
-    "geom:area_square_m":7332646610.193066,
+    "geom:area_square_m":7332645933.618298,
     "geom:bbox":"165.111702,-22.670668,167.555186,-21.315339",
     "geom:latitude":-21.875666,
     "geom:longitude":166.201621,
@@ -188,8 +188,9 @@
         "hasc:id":"NC.SU",
         "qs_pg:id":888225
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NC",
-    "wof:geomhash":"5933f33412547e3962c47b60e1b20203",
+    "wof:geomhash":"13c04a0864cef6c89bb440491d907e6b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -206,7 +207,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636502257,
+    "wof:lastmodified":1695884927,
     "wof:name":"Sud",
     "wof:parent_id":85632473,
     "wof:placetype":"region",

--- a/data/856/752/61/85675261.geojson
+++ b/data/856/752/61/85675261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.834756,
-    "geom:area_square_m":9643375665.903708,
+    "geom:area_square_m":9643376031.349968,
     "geom:bbox":"159.926117,-21.60695,166.082313,-19.109145",
     "geom:latitude":-20.887174,
     "geom:longitude":164.894642,
@@ -248,8 +248,9 @@
         "hasc:id":"NC.NO",
         "qs_pg:id":212378
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NC",
-    "wof:geomhash":"27879fcc4ce3d01b54c96bf7ffc4f991",
+    "wof:geomhash":"b8f6ee3ad216b6a4339702a177cd64ec",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -266,7 +267,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636502257,
+    "wof:lastmodified":1695884927,
     "wof:name":"Nord",
     "wof:parent_id":85632473,
     "wof:placetype":"region",

--- a/data/856/813/09/85681309.geojson
+++ b/data/856/813/09/85681309.geojson
@@ -67,7 +67,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694493127,
+    "wof:lastmodified":1695884284,
     "wof:name":"Minor islands of New Caledonia",
     "wof:parent_id":85632473,
     "wof:placetype":"region",

--- a/data/890/428/961/890428961.geojson
+++ b/data/890/428/961/890428961.geojson
@@ -330,7 +330,7 @@
         }
     ],
     "wof:id":890428961,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886972,
     "wof:name":"B\u00e9lep",
     "wof:parent_id":85675261,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.